### PR TITLE
Fix a couple of issues.

### DIFF
--- a/src/asynch_interface.c
+++ b/src/asynch_interface.c
@@ -439,8 +439,11 @@ void Asynch_Free(AsynchSolver* asynch)
     Destroy_Workspace(&asynch->workspace, asynch->globals->max_rk_stages, asynch->globals->max_parents);
     free(asynch->getting);
     
-    if (asynch->outputfile)
+    if (asynch->outputfile != NULL)
+    {
         fclose(asynch->outputfile);
+        asynch->outputfile = NULL;
+    }
 
     for (i = 0; i < asynch->N; i++)
         Destroy_Link(&asynch->sys[i], asynch->rkdfilename[0] != '\0', asynch->forcings, asynch->globals);
@@ -1074,8 +1077,11 @@ int Asynch_Check_Peakflow_Output(AsynchSolver* asynch, char* name)
 
 int Asynch_Delete_Temporary_Files(AsynchSolver* asynch)
 {
-    if (asynch->outputfile)
+    if (asynch->outputfile != NULL)
+    {
         fclose(asynch->outputfile);
+        asynch->outputfile = NULL;
+    }
 
     int ret_val = RemoveTemporaryFiles(asynch->globals, asynch->my_save_size, NULL);
     //if(ret_val == 1)	printf("[%i]: Error deleting temp file. File does not exist.\n");

--- a/src/system.c
+++ b/src/system.c
@@ -201,10 +201,10 @@ void Destroy_RKMethod(RKMethod* method)
 void Destroy_ErrorData(ErrorData* error)
 {
     assert(error != NULL);
-    free(&error->abstol);
-    free(&error->reltol);
-    free(&error->abstol_dense);
-    free(&error->reltol_dense);
+    free(error->abstol);
+    free(error->reltol);
+    free(error->abstol_dense);
+    free(error->reltol_dense);
 }
 
 //Allocates workspace for RK solvers


### PR DESCRIPTION
In `src/asynch_interface.c`, `asynch->outputfile` can be closed either in `Destroy_Workspace()` or in `Asynch_Delete_Temporary_Files()`, but it must not be closed twice. Avoiding a double-close solves the errors displayed after the computations are completed.

In `src/system.c`, `ErrorData` is leaking. `Destroy_ErrorData()` must call `free()` on the pointers, not their addresses.